### PR TITLE
feat: replace `motion-v` with vanilla js

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "clsx": "^2.1.1",
     "diff": "^7.0.0",
     "lucide-vue-next": "^0.508.0",
-    "motion-v": "1.0.0-beta.2",
     "ofetch": "^1.4.1",
     "reka-ui": "^2.2.1",
     "tailwind-merge": "^3.2.0",
@@ -46,7 +45,6 @@
   },
   "pnpm": {
     "overrides": {
-      "motion-v>@vueuse/core": "^13",
       "reka-ui>@vueuse/core": "^13",
       "reka-ui>@vueuse/shared": "^13"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  motion-v>@vueuse/core: ^13
   reka-ui>@vueuse/core: ^13
   reka-ui>@vueuse/shared: ^13
 
@@ -37,9 +36,6 @@ importers:
       lucide-vue-next:
         specifier: ^0.508.0
         version: 0.508.0(vue@3.5.13(typescript@5.8.3))
-      motion-v:
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2(react@19.1.0)(vue@3.5.13(typescript@5.8.3))
       ofetch:
         specifier: ^1.4.1
         version: 1.4.1
@@ -680,20 +676,6 @@ packages:
       picomatch:
         optional: true
 
-  framer-motion@12.5.0:
-    resolution: {integrity: sha512-buPlioFbH9/W7rDzYh1C09AuZHAk2D1xTA1BlounJ2Rb9aRg84OXexP0GLd+R83v0khURdMX7b5MKnGTaSg5iA==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -705,9 +687,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  hey-listen@1.0.8:
-    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -805,17 +784,6 @@ packages:
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
-  motion-dom@12.7.4:
-    resolution: {integrity: sha512-1ZUHAoSUMMxP6jPqyxlk9XUfb6NxMsnWPnH2YGhrOhTURLcXWbETi6eemoKb60Pe32NVJYduL4B62VQSO5Jq8Q==}
-
-  motion-utils@12.7.2:
-    resolution: {integrity: sha512-XhZwqctxyJs89oX00zn3OGCuIIpVevbTa+u82usWBC6pSHUd2AoNWiYa7Du8tJxJy9TFbZ82pcn5t7NOm1PHAw==}
-
-  motion-v@1.0.0-beta.2:
-    resolution: {integrity: sha512-NjG110Jf2zqdKulV20eMizXo2lutMGdrusqQ8oYdhTZGNLgKcbcxcS/ZF3ibj3C6oKmyhO8twwAW2FZmWmjVrA==}
-    peerDependencies:
-      vue: '>=3.0.0'
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -861,10 +829,6 @@ packages:
 
   quansync@0.2.10:
     resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
-
-  react@19.1.0:
-    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
-    engines: {node: '>=0.10.0'}
 
   reka-ui@2.2.1:
     resolution: {integrity: sha512-oLHiyBn6gTIQGnTnv8G5LQuFp9j8HuUNl0qdnW3XPhFb/07hrxzFpjo2kt/jxOZive+n/XWDbOjSj2h9Hih3qA==}
@@ -1522,22 +1486,12 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
-  framer-motion@12.5.0(react@19.1.0):
-    dependencies:
-      motion-dom: 12.7.4
-      motion-utils: 12.7.2
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.1.0
-
   fsevents@2.3.3:
     optional: true
 
   globals@15.15.0: {}
 
   graceful-fs@4.2.11: {}
-
-  hey-listen@1.0.8: {}
 
   hookable@5.5.3: {}
 
@@ -1615,24 +1569,6 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
-  motion-dom@12.7.4:
-    dependencies:
-      motion-utils: 12.7.2
-
-  motion-utils@12.7.2: {}
-
-  motion-v@1.0.0-beta.2(react@19.1.0)(vue@3.5.13(typescript@5.8.3)):
-    dependencies:
-      '@vueuse/core': 13.1.0(vue@3.5.13(typescript@5.8.3))
-      framer-motion: 12.5.0(react@19.1.0)
-      hey-listen: 1.0.8
-      motion-dom: 12.7.4
-      vue: 3.5.13(typescript@5.8.3)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - react
-      - react-dom
-
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -1678,9 +1614,6 @@ snapshots:
       source-map-js: 1.2.1
 
   quansync@0.2.10: {}
-
-  react@19.1.0:
-    optional: true
 
   reka-ui@2.2.1(vue@3.5.13(typescript@5.8.3)):
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
         manualChunks: {
           'vue': ['vue'],
           'utils': ['@vueuse/core', 'ofetch', 'diff'],
-          'motion': ['motion-v'],
           'ai-sdk': ['@xsai-ext/providers-cloud', '@xsai/stream-text'],
           'ui': ['reka-ui', 'lucide-vue-next', 'vue-sonner', 'vee-validate', 'tailwind-merge', 'clsx', 'class-variance-authority'],
         }


### PR DESCRIPTION
resolves #3

This PR completely  removes `motion-v`, which reduces bundle size by `45kb(gzip)` ↓, by implementing the animation with vanilla js. 🎉